### PR TITLE
feat: implement vec3 math utility class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ set(CMAKE_CXX_STANDARD 14)
 
 add_executable(NOAM_RayTracer
         src/main.cpp
-        src/Point.cpp)
+        include/Vec3.h
+)
 
 target_include_directories(NOAM_RayTracer PUBLIC include)
 

--- a/include/Point.h
+++ b/include/Point.h
@@ -1,9 +1,0 @@
-#ifndef NOAM_RAYTRACER_POINT_H
-#define NOAM_RAYTRACER_POINT_H
-
-
-class Point {
-};
-
-
-#endif //NOAM_RAYTRACER_POINT_H

--- a/include/Vec3.h
+++ b/include/Vec3.h
@@ -1,0 +1,113 @@
+#ifndef NOAM_RAYTRACER_VEC3_H
+#define NOAM_RAYTRACER_VEC3_H
+#include <cmath>
+#include <fstream>
+
+class Vec3 {
+public :
+    double e[3];
+
+    Vec3(): e{0,0,0}{}
+    Vec3(double e0, double e1, double e2):e{e0,e1,e2}{}
+
+    double getX() const {return e[0];}
+    double getY() const {return e[1];}
+    double getZ() const{return e[2];}
+
+    Vec3& operator=(const Vec3& vector) {
+        e[0]=vector.e[0];
+        e[1]=vector.e[1];
+        e[2]=vector.e[2];
+
+        return *this;
+    }
+
+    Vec3& operator+=(const Vec3& vector) {
+        e[0] = vector.getX();
+        e[1] = vector.getY();
+        e[2] = vector.getZ();
+        return *this;
+    }
+    Vec3& operator-() {
+        e[0] = -getX();
+        e[1] = -getY();
+        e[2] = -getZ();
+        return *this;
+    }
+    Vec3& operator*=(const Vec3& vector) {
+        e[0] = vector.getX()*getX();
+        e[1] = vector.getY()*getY();
+        e[2] = vector.getZ()*getZ();
+        return *this;
+    }
+    Vec3& operator*=(double scalar) {
+        e[0] *= scalar;
+        e[1] *= scalar;
+        e[2] *= scalar;
+        return *this;
+    }
+    Vec3& operator/=(double denominator) {
+
+        return *this*=1/denominator;
+    }
+    double getLengh() {
+        double lenghSquared = getX()*getX()+getY()*getY()+getZ()*getZ();
+        return std::sqrt(lenghSquared);
+    }
+    Vec3& unit_vector() {
+        return *this/=getLengh();
+    }
+    double operator[](int i) const {
+        return e[i];
+    }
+    double& operator[](int i) {
+        return e[i];
+    }
+};
+inline std::ostream& operator<<(std::ostream& os, const Vec3& vector) {
+    return os<<vector[0]<<' '<<vector[1]<<' '<<vector[2];
+}
+inline Vec3 operator*(const Vec3& vector, double scalar) {
+    Vec3 vectorMultiplied = vector;
+    vectorMultiplied*=scalar;
+    return vectorMultiplied;
+}
+inline Vec3 operator*(double scalar,const Vec3& vector) {
+    Vec3 vectorMultiplied = vector;
+    vectorMultiplied*=scalar;
+    return vectorMultiplied;
+}
+inline Vec3 operator+(const Vec3& vector1, const Vec3& vector2) {
+    Vec3 vectorSomme = vector1;
+    vectorSomme+=vector2;
+    return vectorSomme;
+}
+inline Vec3 operator-(const Vec3& vector1, const Vec3& vector2) {
+    Vec3 vectorInverseOfVector2 = vector2;
+    vectorInverseOfVector2 = -vectorInverseOfVector2;
+    return vector1+vectorInverseOfVector2;
+}
+inline Vec3 operator/(const Vec3& vector, double denominator) {
+    Vec3 vectorDivided = vector;
+    vectorDivided/=denominator;
+    return vectorDivided;
+}
+inline Vec3 dot(const Vec3& vector1, const Vec3& vector2) {
+    Vec3 vectorDot;
+    vectorDot.e[0]= vector1.getX()*vector2.getX();
+    vectorDot.e[1]= vector1.getY()*vector2.getY();
+    vectorDot.e[2]= vector1.getZ()*vector2.getZ();
+
+    return vectorDot;
+}
+inline Vec3 vectorial(const Vec3& vector1, const Vec3& vector2) {
+    Vec3 vectorial;
+    vectorial.e[0]= vector1.getY()*vector2.getZ()-vector1.getZ()*vector2.getY();
+    vectorial.e[1]= vector1.getZ()*vector2.getX()-vector1.getX()*vector2.getZ();
+    vectorial.e[2]= vector1.getX()*vector2.getY()-vector1.getY()*vector2.getX();
+    return vectorial;
+}
+
+
+
+#endif

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -1,5 +1,0 @@
-//
-// Created by nourb on 16/03/2026.
-//
-
-#include "Point.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include "Vec3.h"
 
 int main() {
     int width = 256;
@@ -15,6 +16,7 @@ int main() {
     ofs <<"\n255\n";
 
     for (int i = 0; i<height; i++) {
+
         for (int j = 0; j<width; j++) {
             auto r = double(j)/(width-1);
             auto b = double(i)/(height-1);
@@ -27,5 +29,8 @@ int main() {
         }
     }
     ofs.close();
+    std::clog << "\rDone.                 \n";
+    Vec3 v(1,3,4);
+    std::cout<<v;
 
 }


### PR DESCRIPTION
## Summary
This pull request introduces the `Vec3` math utility class used in the ray tracer.

The class represents a 3D vector and provides basic vector operations required for geometric computations, ray directions, and color manipulation.

## Changes
- Added `Vec3` class implementation
- Implemented constructors and coordinate accessors (`getX`, `getY`, `getZ`)
- Implemented element access operator `operator[]`
- Added arithmetic operators:
  - `operator+=`
  - `operator-=`
  - `operator*=`
  - `operator/=`
- Implemented scalar multiplication and division
- Implemented vector addition and subtraction
- Implemented dot product and cross product helpers
- Added stream output operator `<<` for debugging and logging

## Purpose
The `Vec3` class will serve as the core mathematical structure of the ray tracer and will be used to represent:
- 3D points
- direction vectors
- colors
- geometric calculations

## Commit
`feat: implement vec3 math utility class`