### PR TITLE
feat(render): implémentation de la sphère et visualisation des normales

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(NOAM_RayTracer)
 
 set(CMAKE_CXX_STANDARD 14)
 
-add_executable(NOAM_RayTracer
+add_executable(main
         src/main.cpp
         include/Vec3.h
         include/Color.h
@@ -11,6 +11,6 @@ add_executable(NOAM_RayTracer
         include/Ray.h
 )
 
-target_include_directories(NOAM_RayTracer PUBLIC include)
+target_include_directories(main PUBLIC include)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(main
         include/Color.h
         src/Ray.cpp
         include/Ray.h
+        include/Sphere.h
 )
 
 target_include_directories(main PUBLIC include)

--- a/include/Color.h
+++ b/include/Color.h
@@ -2,6 +2,7 @@
 #ifndef NOAM_RAYTRACER_COLOR_H
 #define NOAM_RAYTRACER_COLOR_H
 #include "Vec3.h"
+#include "Color.h"
 #include <iostream>
 
 using Color = Vec3;

--- a/include/Ray.h
+++ b/include/Ray.h
@@ -10,15 +10,13 @@ using Point3 = Vec3;
 class Ray {
 public:
     Ray();
-    Ray(const Point3& p_origin, const Vec3& p_direction );
+    Ray(Point3 p_origin, Vec3 p_direction );
 
-    const Point3& getOrigin() const;
-    const Vec3& getDirection() const;
-
-    Point3 position(double t) const;
-private:
     Point3 m_origin;
     Vec3 m_direction;
+
+    Point3 position(double t) const;
+
 };
 
 

--- a/include/Sphere.h
+++ b/include/Sphere.h
@@ -13,7 +13,7 @@ public:
         double m_rayon;
         Point m_centre;
 
-        Sphere(double p_rayon, Point p_centre):m_rayon(p_rayon),m_centre(p_centre){}
+        Sphere(double p_rayon, Point p_centre): m_rayon(p_rayon),m_centre(p_centre) {}
 
 };
 

--- a/include/Sphere.h
+++ b/include/Sphere.h
@@ -1,0 +1,21 @@
+//
+// Created by nourb on 01/04/2026.
+//
+
+#ifndef NOAM_RAYTRACER_SPHERE_H
+#define NOAM_RAYTRACER_SPHERE_H
+#include "Vec3.h"
+
+using Vec3 = Point;
+
+class Sphere {
+public:
+        double m_rayon;
+        Point m_centre;
+
+        Sphere(double p_rayon, Point p_centre):m_rayon(p_rayon),m_centre(p_centre){}
+
+};
+
+
+#endif //NOAM_RAYTRACER_SPHERE_H

--- a/include/Vec3.h
+++ b/include/Vec3.h
@@ -22,9 +22,9 @@ public :
     }
 
     Vec3& operator+=(const Vec3& vector) {
-        e[0] = vector.getX();
-        e[1] = vector.getY();
-        e[2] = vector.getZ();
+        e[0] += vector.getX();
+        e[1] += vector.getY();
+        e[2] += vector.getZ();
         return *this;
     }
     Vec3& operator-() {
@@ -47,14 +47,20 @@ public :
     }
     Vec3& operator/=(double denominator) {
 
-        return *this*=1/denominator;
+        return *this*=1.0/denominator;
     }
     double getLengh() {
         double lenghSquared = getX()*getX()+getY()*getY()+getZ()*getZ();
         return std::sqrt(lenghSquared);
     }
-    Vec3& unit_vector() {
-        return *this/=getLengh();
+    Vec3 unit_vector() {
+        double len = getLengh();
+
+        if (len < 1e-8) {
+            return Vec3(0,0,0);
+        }
+
+        return *this/=len;
     }
     double operator[](int i) const {
         return e[i];
@@ -63,6 +69,7 @@ public :
         return e[i];
     }
 };
+using Point = Vec3;
 inline std::ostream& operator<<(std::ostream& os, const Vec3& vector) {
     return os<<vector[0]<<' '<<vector[1]<<' '<<vector[2];
 }

--- a/include/Vec3.h
+++ b/include/Vec3.h
@@ -98,11 +98,11 @@ inline Vec3 operator/(const Vec3& vector, double denominator) {
     vectorDivided/=denominator;
     return vectorDivided;
 }
-inline Vec3 dot(const Vec3& vector1, const Vec3& vector2) {
-    Vec3 vectorDot;
-    vectorDot.e[0]= vector1.getX()*vector2.getX();
-    vectorDot.e[1]= vector1.getY()*vector2.getY();
-    vectorDot.e[2]= vector1.getZ()*vector2.getZ();
+inline double dot(const Vec3& vector1, const Vec3& vector2) {
+    double vectorDot = 0;
+    vectorDot+= vector1.getX()*vector2.getX();
+    vectorDot+= vector1.getY()*vector2.getY();
+    vectorDot+= vector1.getZ()*vector2.getZ();
 
     return vectorDot;
 }

--- a/src/Ray.cpp
+++ b/src/Ray.cpp
@@ -3,17 +3,9 @@
 //
 
 #include "../include/Ray.h"
-Ray::Ray():m_origin(0,0,0),m_direction(0,0,0){}
-Ray::Ray(const Point3& p_origin, const Vec3& p_direction ):m_origin(p_origin), m_direction(p_direction){}
+Ray::Ray():m_origin(0.0,0.0,0.0),m_direction(0.0,0.0,0.0){}
+Ray::Ray(Point3 p_origin, Vec3 p_direction ):m_origin(p_origin), m_direction(p_direction){}
 
-const Point3&
-    Ray::getOrigin() const {
-    return m_origin;
-}
-const Vec3&
-    Ray::getDirection() const {
-    return m_direction;
-}
 
 Point3
     Ray::position(double t) const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,31 +2,56 @@
 #include <fstream>
 #include "Vec3.h"
 #include "Color.h"
+#include "Ray.h"
+
 using Color = Vec3;
+Color ray_color(const Ray& ray) {
+    auto direction = ray.m_direction;
+    Vec3 unit_direction = direction.unit_vector();
+    auto a = 0.5*(unit_direction.getY() + 1.0);
+    return (1.0-a)*Color(1.0, 1.0, 1.0) + a*Color(0.5, 0.7, 1.0);
+}
 int main() {
-    int width = 256;
-    int height = 256;
+    double focalLengh = 1.0;
+    int imageWidth = 400;
+    double ratio = 16.0/10.0;
+    int imageHeight = static_cast<int>(imageWidth/ratio);
+
+    imageHeight =(imageHeight<1)? 1 : imageHeight;
+    double viewport_height = 2.0;
+    double viewport_width = viewport_height*(static_cast<double>(imageWidth)/imageHeight);
+    Point centreCamera(0,0,0);
+
+    Vec3 viewport_u(viewport_width,0,0);
+    Vec3 viewport_v(0,-viewport_height,0);
+    Vec3 viewportZcoordonates(0,0,-focalLengh);
+
+    Vec3 pixelDeltaWidth = viewport_u/imageWidth;
+    Vec3 pixelDeltaHeight = viewport_v/imageHeight;
+
+    Point viewportUpperLeft = centreCamera  +viewportZcoordonates- viewport_u/2 - viewport_v/2;
+    Point pixelOrigin = viewportUpperLeft + (pixelDeltaWidth + pixelDeltaHeight)/2;
 
     std::ofstream ofs("../image/image.ppm");
-
     if (!ofs) {
         std::cout<<"Ne trouve pas";
     }
 
-    ofs << "P3\n" << width << ' ' <<height;
+    ofs << "P3\n" << imageWidth << ' ' <<imageHeight;
     ofs <<"\n255\n";
 
-    for (int i = 0; i<height; i++) {
-        double normalisedI = double(i) / (height - 1);
+    for (int i = 0; i<imageHeight; i++) {
+        for (int j = 0; j<imageWidth; j++) {
+            Point pixelCenter = pixelOrigin + j*pixelDeltaWidth + i*pixelDeltaHeight;
+            Vec3 ray_direction = pixelCenter-centreCamera;
 
-        for (int j = 0; j<width; j++) {
-            double normalisedJ = double(j) / (width - 1);
-            Color color(normalisedI,0,normalisedJ);
-            write_color(ofs, color);
+            Ray r(centreCamera, ray_direction);
+
+            Color pixel_color = ray_color(r);
+            write_color(ofs, pixel_color);
         }
     }
-    ofs.close();
-    std::clog << "\rDone.                 \n";
+
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,13 +3,46 @@
 #include "Vec3.h"
 #include "Color.h"
 #include "Ray.h"
+#include "Sphere.h"
+#include <cmath>
 
 using Color = Vec3;
+bool hit_sphere(const Ray& ray, const Sphere& sphere) {
+    Vec3 directionRay = ray.m_direction;
+    Point originRay = ray.m_origin;
+
+    Vec3 centre = sphere.m_centre;
+    double r = sphere.m_rayon;
+
+    Vec3 vectorOriginToCenter = centre-originRay;
+
+    double a = dot(directionRay,directionRay);
+    double b = dot(-2*directionRay, vectorOriginToCenter);
+    double c = dot(vectorOriginToCenter,vectorOriginToCenter)-r*r;
+
+    bool hit_sphere = (b*b-4*a*c>-1);
+    if (hit_sphere){return true;}
+    return false;
+}
 Color ray_color(const Ray& ray) {
     auto direction = ray.m_direction;
+
+    double r = 15;
+    Point centre(10,0,30);
+
+    Sphere sphere(r,centre);
+
     Vec3 unit_direction = direction.unit_vector();
-    auto a = 0.5*(unit_direction.getY() + 1.0);
-    return (1.0-a)*Color(1.0, 1.0, 1.0) + a*Color(0.5, 0.7, 1.0);
+    double a;
+    a = 0.5*(unit_direction.getY() + 1.0);
+
+    if (hit_sphere(ray,sphere)) {
+        return Color(1,0,0);
+    }
+    else {
+        return (1.0-a)*Color(1.0, 1.0, 1.0) + a*Color(0.5, 0.7, 1.0);
+    }
+
 }
 int main() {
     double focalLengh = 1.0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,13 @@
 #include <cmath>
 
 using Color = Vec3;
-bool hit_sphere(const Ray& ray, const Sphere& sphere) {
+double hit_sphere(const Ray& ray, const Sphere& sphere) {
     Vec3 directionRay = ray.m_direction;
     Point originRay = ray.m_origin;
 
     Vec3 centre = sphere.m_centre;
     double r = sphere.m_rayon;
+
 
     Vec3 vectorOriginToCenter = centre-originRay;
 
@@ -20,26 +21,30 @@ bool hit_sphere(const Ray& ray, const Sphere& sphere) {
     double b = dot(-2*directionRay, vectorOriginToCenter);
     double c = dot(vectorOriginToCenter,vectorOriginToCenter)-r*r;
 
-    bool hit_sphere = (b*b-4*a*c>-1);
-    if (hit_sphere){return true;}
-    return false;
-}
-Color ray_color(const Ray& ray) {
-    auto direction = ray.m_direction;
-
-    double r = 15;
-    Point centre(10,0,30);
-
-    Sphere sphere(r,centre);
-
-    Vec3 unit_direction = direction.unit_vector();
-    double a;
-    a = 0.5*(unit_direction.getY() + 1.0);
-
-    if (hit_sphere(ray,sphere)) {
-        return Color(1,0,0);
+    double discriminant = b*b-4*a*c;
+    if (discriminant < 0) {
+        return -1.0;
     }
     else {
+        return (-b - std::sqrt(discriminant) ) / (2.0*a);
+    }
+
+}
+Color ray_color(const Ray& ray) {
+
+    Vec3 centre(0,0,-1);
+    auto t = hit_sphere(ray, Sphere(0.5,centre));
+    if (t >=0.0) {
+        Vec3 norme = ray.position(t) - Vec3(0,0,-1);
+        Vec3 N = norme.unit_vector();
+
+        return 0.5*Color(N.getX()+1, N.getY()+1, N.getZ()+1);
+    }
+    else {
+        auto direction = ray.m_direction;
+        Vec3 unit_direction = direction.unit_vector();
+        auto a = 0.5*(unit_direction.getY() + 1.0);
+
         return (1.0-a)*Color(1.0, 1.0, 1.0) + a*Color(0.5, 0.7, 1.0);
     }
 
@@ -84,7 +89,6 @@ int main() {
             write_color(ofs, pixel_color);
         }
     }
-
 
 
 


### PR DESCRIPTION
## 🎯 Description
Cette Pull Request introduit la première géométrie solide dans notre moteur de lancer de rayons : la sphère. Elle implémente la logique mathématique d'intersection rayon-sphère et ajoute un système de *shading* basique utilisant les normales de surface pour valider visuellement la géométrie en 3D.

## 🛠️ Changements majeurs
* **Logique d'intersection :** Résolution de l'équation quadratique pour calculer l'intersection entre un rayon et une sphère (calcul de `a`, `b`, `c` et évaluation correcte du discriminant mathématique).
* **Calcul des normales :** Implémentation du calcul du vecteur normal au point d'intersection (`t`) pointant vers l'extérieur de la surface.
* **Shading des normales :** Ajout d'une visualisation colorimétrique. Les composantes `(x, y, z)` du vecteur normal (comprises entre -1.0 et 1.0) sont normalisées et mappées vers l'espace RGB `(0.0 à 1.0)` via la formule `0.5 * (N + 1)`.
* **Correction de bugs :** Résolution d'un problème d'évaluation booléenne silencieuse lors du calcul du discriminant qui faussait le paramètre `t` de l'intersection.

## 📸 Résultat visuel
<img width="997" height="537" alt="image" src="https://github.com/user-attachments/assets/7dea012c-ecff-482c-b08e-aba7614a9989" />

## 🧪 Détails techniques & Prochaines étapes
* Le moteur de rendu identifie correctement le premier point d'impact (la plus petite racine positive de l'équation).
* **Prochaine étape logique :** Mettre en place une liste d'objets (Hittable List) pour gérer plusieurs sphères à l'écran, gérer l'anti-aliasing, ou attaquer les matériaux (diffus, métal).